### PR TITLE
Update framework Version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,7 +1,7 @@
 app: todo-list-serverless
 service: serverless-rest-api-with-dynamodb
 
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0 <=2.17.0"
 
 provider:
   name: aws


### PR DESCRIPTION
Update `serverless.yml` frameworkVersion to `2.17.0`:

- Because this version is supported by Serverless Framework Pipeline CI/CD